### PR TITLE
fix: simplify table cell text alignment and remove vertical align

### DIFF
--- a/lib/table.ts
+++ b/lib/table.ts
@@ -1,12 +1,5 @@
 import type { Tokens } from "marked"
-import {
-  AlignmentType,
-  ImportedXmlComponent,
-  Paragraph,
-  Table,
-  TableCell,
-  TableRow,
-} from "docx"
+import { AlignmentType, ImportedXmlComponent, Paragraph, Table, TableCell, TableRow } from "docx"
 import { inlineTokensToRuns } from "./inline"
 
 interface ParsedTableCell {


### PR DESCRIPTION
## Summary

- Removes the `cellAlignType` helper function and `VerticalAlignTable` import in favor of inline spread expressions for alignment
- Drops `VerticalAlignTable.CENTER` from `TableCell`, which was overriding per-row vertical alignment styles
- Left alignment is now the implicit default (no property set) rather than explicitly set via `AlignmentType.LEFT`

## Test plan

- [ ] Convert a Markdown file with a table that has left, center, and right aligned columns and verify alignment renders correctly in the output `.docx`
- [ ] Verify no TypeScript errors (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)