### PR TITLE
fix: use unique bookmark IDs for heading anchors

### DIFF
--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -197,6 +197,13 @@ describe("headings", () => {
     const body = await bodyXml("## Two  Words")
     expect(body).toContain('w:name="two-words"')
   })
+
+  test("multiple headings get unique bookmark ids", async () => {
+    const body = await bodyXml("# First\n\n## Second\n\n### Third")
+    const ids = [...body.matchAll(/w:bookmarkStart[^>]+w:id="(\d+)"/g)].map((m) => m[1])
+    expect(ids).toHaveLength(3)
+    expect(new Set(ids).size).toBe(3)
+  })
 })
 
 describe("inline formatting", () => {
@@ -222,6 +229,15 @@ describe("inline formatting", () => {
     const body = await bodyXml("Use `foo()` here")
     expect(body).toContain('w:val="InlineCode"')
     expect(body).toContain("foo()")
+  })
+
+  test("`code#with-hash` renders as a single InlineCode run — not split at #", async () => {
+    const body = await bodyXml("Reference `package.json#name` here")
+    // Should contain the full text as one run
+    expect(body).toContain("package.json#name")
+    // Only ONE InlineCode run should exist
+    const codeRuns = body.match(/w:val="InlineCode"/g) ?? []
+    expect(codeRuns).toHaveLength(1)
   })
 
   test("[link](url) renders as hyperlink with Hyperlink style", async () => {

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -1,7 +1,8 @@
 import type { Tokens } from "marked"
 import {
   AlignmentType,
-  Bookmark,
+  BookmarkEnd,
+  BookmarkStart,
   BorderStyle,
   Document,
   Footer,
@@ -53,6 +54,7 @@ async function tokensToDocx(
   const elements: Array<Paragraph | Table> = []
   const orderedRefs: string[] = []
   let firstAppendix = true
+  let bookmarkId = 0
 
   for (const token of tokens) {
     switch (token.type) {
@@ -65,9 +67,12 @@ async function tokensToDocx(
         }
         const slug = text ? headingSlug(text) : undefined
         const runs = inlineTokensToRuns(inlineTokens)
+        const id = ++bookmarkId
         elements.push(
           new Paragraph({
-            children: slug ? [new Bookmark({ id: slug, children: runs })] : runs,
+            children: slug
+              ? [new BookmarkStart(slug, id), ...runs, new BookmarkEnd(id)]
+              : runs,
             style: HEADING_STYLES[(token["depth"] as number | undefined) ?? 1] ?? "Heading1",
           }),
         )


### PR DESCRIPTION
The `docx` library's `Bookmark` class creates an isolated counter per instance, so every heading bookmark got `w:id="1"`. Duplicate bookmark IDs are invalid OOXML and trigger Word's document-repair on open, which can produce unpredictable rendering including splitting inline code spans containing `#`.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)