### PR TITLE
fix: reduce default font size to 11pt and pin footer text at 10pt

### DIFF
--- a/lib/document-styles.ts
+++ b/lib/document-styles.ts
@@ -28,7 +28,7 @@ function fontSizes(basePt: number): FontSizes {
     heading3: hp(basePt + 4),
     heading456: hp(basePt + 2),
     codeBlock: hp(basePt),
-    footerText: hp(basePt - 3),
+    footerText: hp(10),
   }
 }
 

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -485,14 +485,14 @@ describe("font size scaling", () => {
     return map
   }
 
-  test("default (no fontSize) → Normal = 24 half-points", async () => {
+  test("default (no fontSize) → Normal = 22 half-points", async () => {
     const sizes = await styleSizes()
-    expect(sizes.get("Normal")).toBe(24)
+    expect(sizes.get("Normal")).toBe(22)
   })
 
-  test("fontSize: 12 explicit === no fontSize implicit", async () => {
+  test("fontSize: 11 explicit === no fontSize implicit", async () => {
     const implicit = await styleSizes()
-    const explicit = await styleSizes({ fontSize: 12 })
+    const explicit = await styleSizes({ fontSize: 11 })
     for (const [id, size] of implicit) {
       expect(explicit.get(id)).toBe(size)
     }
@@ -523,9 +523,11 @@ describe("font size scaling", () => {
     expect(sizes.get("CodeBlock")).toBe(20)
   })
 
-  test("fontSize: 10 → FooterText = 14 half-points (10-3=7pt)", async () => {
-    const sizes = await styleSizes({ fontSize: 10 })
-    expect(sizes.get("FooterText")).toBe(14)
+  test("FooterText is always 20 half-points (fixed 10pt) regardless of fontSize", async () => {
+    const sizesDefault = await styleSizes()
+    expect(sizesDefault.get("FooterText")).toBe(20)
+    const sizesCustom = await styleSizes({ fontSize: 10 })
+    expect(sizesCustom.get("FooterText")).toBe(20)
   })
 
   test("CodeBlockSpacing style is not present", async () => {

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -271,7 +271,7 @@ export interface ConvertOptions {
   lineNumbers?: boolean
   /** Raw XML string extracted from word/styles.xml in a .dotx template */
   externalStylesXml?: string
-  /** Base font size in pt; all readable styles scale from this (default: 12) */
+  /** Base font size in pt; all readable styles scale from this (default: 11) */
   fontSize?: number
 }
 
@@ -330,7 +330,7 @@ export async function convertMarkdownToDocx(
   })
 
   return new Document({
-    ...buildStyleOptions(options.fontSize ?? 12, options.externalStylesXml),
+    ...buildStyleOptions(options.fontSize ?? 11, options.externalStylesXml),
     numbering: buildNumbering(orderedRefs),
     sections: [
       {


### PR DESCRIPTION
## Summary

- Changes default `basePt` from 12 → 11, making normal body text 11pt
- Pins `FooterText` at a fixed 10pt (previously `basePt - 3`, which would drop to 8pt at the new default)
- Updates existing font size scaling tests to reflect new defaults

## Test plan

- [x] All 78 existing tests pass
- [x] `FooterText` fixed-size test covers both default and custom `fontSize` values
- [x] Visual preview inspected and looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)