### PR TITLE
fix: suppress spacing.before on first appendix heading after page break

### DIFF
--- a/.claude/skills/preview/assets/preview.md
+++ b/.claude/skills/preview/assets/preview.md
@@ -100,3 +100,19 @@ Back to a paragraph. Then an ordered list.
 2. Two
 
 Then another paragraph to close.
+
+## Appendix A: Reference Tables
+
+This is the first appendix. The heading above should appear at the top of a new page with no blank line before it.
+
+| Term      | Definition                       |
+| --------- | -------------------------------- |
+| Markdown  | Lightweight markup language      |
+| docx      | Microsoft Word document format   |
+| Paragraph | Block of text in a Word document |
+
+## Appendix B: Additional Notes
+
+This is the second appendix. It should follow directly without a forced page break.
+
+Some closing notes here.

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -68,6 +68,7 @@ async function tokensToDocx(
             children: slug ? [new Bookmark({ id: slug, children: runs })] : runs,
             style: HEADING_STYLES[(token["depth"] as number | undefined) ?? 1] ?? "Heading1",
             pageBreakBefore: isFirstAppendix,
+            spacing: isFirstAppendix ? { before: 0 } : undefined,
           }),
         )
         break


### PR DESCRIPTION
## Summary

- `Heading2`+ styles define `spacing.before` (e.g. 280 twips for H2), which rendered as a visible blank gap at the top of the new page when `pageBreakBefore` was applied to the first appendix heading
- Fix overrides `spacing.before` to `0` on that heading so it sits flush at the top of the page
- Adds an appendix section to the preview fixture so this scenario is visually verifiable going forward

## Test plan

- [ ] Run `/preview` and scroll to **Appendix A** — heading should appear flush at the top of a new page with no blank line above it
- [ ] **Appendix B** should follow normally without a page break

🤖 Generated with [Claude Code](https://claude.com/claude-code)