### PR TITLE
improve install script success output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,15 +43,14 @@ if [ -z "$LATEST" ]; then
   exit 1
 fi
 
+IS_UPDATE=0
 if [ -x "$INSTALL_PATH" ]; then
   CURRENT=$("$INSTALL_PATH" --version 2>/dev/null || echo "")
   if [ "$CURRENT" = "$LATEST" ]; then
-    echo "Already up to date ($LATEST)"
+    echo "${BIN_NAME} is already up to date (${LATEST})"
     exit 0
   fi
-  echo "Updating $CURRENT → $LATEST..."
-else
-  echo "Installing $LATEST..."
+  IS_UPDATE=1
 fi
 
 URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARTIFACT}"
@@ -66,14 +65,30 @@ if [ -n "$LINK_PATH" ]; then
   mkdir -p "$LINK_DIR"
   ln -sf "$INSTALL_PATH" "$LINK_PATH"
 fi
-echo "Done."
+
+DISPLAY_PATH="${LINK_PATH:-$INSTALL_PATH}"
+# Shorten $HOME to ~
+DISPLAY_PATH_SHORT=$(echo "$DISPLAY_PATH" | sed "s|^$HOME|~|")
+
+echo ""
+if [ "$IS_UPDATE" = "1" ]; then
+  echo "✔ ${BIN_NAME} successfully updated!"
+else
+  echo "✔ ${BIN_NAME} successfully installed!"
+fi
+echo ""
+echo "  Version:  ${LATEST}"
+echo "  Location: ${DISPLAY_PATH_SHORT}"
+echo ""
+echo "  Next: Run ${BIN_NAME} --help to get started"
+echo ""
 
 case ":$PATH:" in
   *":${XDG_BIN_HOME}:"*) ;;
   *)
-    echo ""
     echo "Note: ${XDG_BIN_HOME} is not in your PATH."
     echo "Add the following to your shell profile:"
     echo "  export PATH=\"\$PATH:${XDG_BIN_HOME}\""
+    echo ""
     ;;
 esac


### PR DESCRIPTION
## Summary

- Shows a styled success block after install/update with version, location, and a next-steps hint
- Distinguishes between fresh install ("successfully installed!") and upgrade ("successfully updated!")
- Location path uses the symlink (`~/.local/bin/...`) when present, with `$HOME` shortened to `~`
- Removes the old "Installing..." / "Updating X → Y..." / "Done." lines in favour of the single success block

## Test plan

- [ ] Fresh install: check output shows correct version, `~/.local/bin/markdown-to-docx`, and next-steps hint
- [ ] Re-run install at same version: check "already up to date" one-liner fires and exits
- [ ] Install older version then re-run: check "successfully updated!" fires
- [ ] Install with `INSTALL_DIR` override: check location shows the override path

🤖 Generated with [Claude Code](https://claude.com/claude-code)