### PR TITLE
fix: pin build to bun 1.3.11, add smoke-test gate before publish

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,9 +1,17 @@
 name: Setup
 description: Checkout, install Bun, and install dependencies
 
+inputs:
+  bun-version:
+    description: Bun version to install (defaults to latest)
+    required: false
+    default: latest
+
 runs:
   using: composite
   steps:
     - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
     - run: bun ci
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.tag }}
       - uses: ./.github/actions/setup
+        with:
+          # bun 1.3.12 produces broken darwin binaries when cross-compiled from Linux
+          bun-version: 1.3.11
       - name: Build
         run: bun build --compile --target=${{ matrix.target }} --outfile=${{ matrix.artifact }} bin/markdown-to-docx.ts
       - name: Upload binary to release
@@ -100,9 +103,41 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ needs.release.outputs.tag }}" "${{ matrix.artifact }}" --repo "${{ github.repository }}"
 
+  smoke-test:
+    name: Smoke test (${{ matrix.artifact }})
+    needs: [release, build]
+    strategy:
+      matrix:
+        include:
+          - artifact: markdown-to-docx-linux-x64
+            runner: ubuntu-latest
+          - artifact: markdown-to-docx-darwin-arm64
+            runner: macos-latest
+          - artifact: markdown-to-docx-darwin-x64
+            runner: macos-13
+          - artifact: markdown-to-docx-windows-x64.exe
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Download binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${{ needs.release.outputs.tag }}" --pattern "${{ matrix.artifact }}" --repo "${{ github.repository }}"
+      - name: Smoke test (unix)
+        if: runner.os != 'Windows'
+        run: |
+          chmod +x "${{ matrix.artifact }}"
+          ./"${{ matrix.artifact }}" --help
+          ./"${{ matrix.artifact }}" --version
+      - name: Smoke test (windows)
+        if: runner.os == 'Windows'
+        run: |
+          .\${{ matrix.artifact }} --help
+          .\${{ matrix.artifact }} --version
+
   publish:
     name: Publish release
-    needs: [release, build]
+    needs: [release, build, smoke-test]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Bun 1.3.12 has a regression where `bun build --compile` produces broken darwin binaries when cross-compiled from Linux (exits with SIGKILL / 137). v0.2.2 was built with 1.3.11 and worked; v0.3.0 was built with 1.3.12 and is broken. The code diff between the two releases is trivial — this is purely a toolchain bug.
- Pins the build job to Bun 1.3.11 via a new `bun-version` input on the setup action.
- Adds a `smoke-test` matrix job that downloads each released binary onto its native runner (ubuntu, macos-latest, macos-13, windows) and runs `--help` and `--version` before `publish` is allowed to promote the draft to latest — so this class of breakage can't ship again.

## Test plan

- [ ] After merge, cut a 0.3.1 patch release via the release workflow — smoke-tests should pass and the darwin binary should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)