### PR TITLE
feat: invert bookmark default to opt-in via --bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Options:
   --font-size <n>    Base font size in pt; all styles scale from this (default: 12)
   --footer <text>    Text to display in the bottom-left footer
   --header <text>    Text to display left-aligned in the header (skipped on the first page)
+  --bookmarks        Enable automatic bookmark generation for headings
   --line-numbers     Enable Word's built-in document line numbering
-  --no-bookmarks     Disable automatic bookmark generation for headings
   --page-numbers     Add a right-aligned page number to the footer
   --template <path>  Path to a .dotx template file to load styles from
 

--- a/bin/markdown-to-docx.ts
+++ b/bin/markdown-to-docx.ts
@@ -17,8 +17,8 @@ Options:
   --font-size <n>    Base font size in pt; all styles scale from this (default: 12)
   --footer <text>    Text to display in the bottom-left footer
   --header <text>    Text to display left-aligned in the header (skipped on the first page)
+  --bookmarks        Enable automatic bookmark generation for headings
   --line-numbers     Enable Word's built-in document line numbering
-  --no-bookmarks     Disable automatic bookmark generation for headings
   --page-numbers     Add a right-aligned page number to the footer
   --template <path>  Path to a .dotx template file to load styles from
 
@@ -108,8 +108,8 @@ function parseArgs(args: string[]): {
   const positional = filteredArgs.filter((a) => !a.startsWith("-"))
 
   const knownFlags = new Set([
+    "--bookmarks",
     "--line-numbers",
-    "--no-bookmarks",
     "--page-numbers",
     "--help",
     "--version",
@@ -139,8 +139,8 @@ function parseArgs(args: string[]): {
     outputPath: resolvedOutput,
     templatePath,
     options: {
+      bookmarks: flags.includes("--bookmarks"),
       lineNumbers: flags.includes("--line-numbers"),
-      noBookmarks: flags.includes("--no-bookmarks"),
       footerPageNumber: flags.includes("--page-numbers"),
       headerLabel,
       footerLabel,

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -182,33 +182,33 @@ describe("headings", () => {
     expect(body).not.toContain("<w:pageBreakBefore/>")
   })
 
-  test("heading gets a bookmark with a slugified id", async () => {
+  test("headings do not get bookmarks by default", async () => {
     const body = await bodyXml("## My Section")
+    expect(body).not.toContain("<w:bookmarkStart")
+    expect(body).not.toContain("<w:bookmarkEnd")
+  })
+
+  test("heading gets a bookmark with a slugified id when bookmarks enabled", async () => {
+    const body = await bodyXml("## My Section", { bookmarks: true })
     expect(body).toContain("<w:bookmarkStart")
     expect(body).toContain('w:name="my-section"')
   })
 
   test("heading slug strips punctuation and lowercases", async () => {
-    const body = await bodyXml("# Hello, World!")
+    const body = await bodyXml("# Hello, World!", { bookmarks: true })
     expect(body).toContain('w:name="hello-world"')
   })
 
   test("heading slug collapses multiple spaces/hyphens", async () => {
-    const body = await bodyXml("## Two  Words")
+    const body = await bodyXml("## Two  Words", { bookmarks: true })
     expect(body).toContain('w:name="two-words"')
   })
 
   test("multiple headings get unique bookmark ids", async () => {
-    const body = await bodyXml("# One\n\n## Two\n\n### Three")
+    const body = await bodyXml("# One\n\n## Two\n\n### Three", { bookmarks: true })
     const ids = [...body.matchAll(/w:bookmarkStart[^>]+w:id="(\d+)"/g)].map((m) => m[1])
     expect(ids.length).toBe(3)
     expect(new Set(ids).size).toBe(3)
-  })
-
-  test("noBookmarks suppresses bookmark elements", async () => {
-    const body = await bodyXml("## My Section", { noBookmarks: true })
-    expect(body).not.toContain("<w:bookmarkStart")
-    expect(body).not.toContain("<w:bookmarkEnd")
   })
 })
 

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -66,7 +66,7 @@ async function loadInlineImages(
 async function tokensToDocx(
   tokens: Tokens.Generic[],
   markdownPath: string,
-  noBookmarks = false,
+  bookmarks = false,
 ): Promise<{ elements: Array<Paragraph | Table>; orderedRefs: string[] }> {
   const elements: Array<Paragraph | Table> = []
   const orderedRefs: string[] = []
@@ -83,7 +83,7 @@ async function tokensToDocx(
         const inlineTokens = (token["tokens"] as Tokens.Generic[] | undefined) ?? []
         const isFirstAppendix = firstAppendix && text?.includes("Appendix")
         if (isFirstAppendix) firstAppendix = false
-        const slug = !noBookmarks && text ? headingSlug(text) : undefined
+        const slug = bookmarks && text ? headingSlug(text) : undefined
         const runs = inlineTokensToRuns(inlineTokens)
         const id = ++bookmarkId
         elements.push(
@@ -330,8 +330,8 @@ export interface ConvertOptions {
   externalStylesXml?: string
   /** Base font size in pt; all readable styles scale from this (default: 11) */
   fontSize?: number
-  /** Disable automatic bookmark generation for headings */
-  noBookmarks?: boolean
+  /** Enable automatic bookmark generation for headings */
+  bookmarks?: boolean
 }
 
 export async function convertMarkdownToDocx(
@@ -342,7 +342,7 @@ export async function convertMarkdownToDocx(
   const content = await Bun.file(markdownPath).text()
   const { body, data } = parseFrontmatter(content)
   const tokens = marked.lexer(body) as Tokens.Generic[]
-  const { elements, orderedRefs } = await tokensToDocx(tokens, markdownPath, options.noBookmarks)
+  const { elements, orderedRefs } = await tokensToDocx(tokens, markdownPath, options.bookmarks)
 
   // CLI flags take precedence; frontmatter.title is the fallback for headerLabel
   const headerLabel =


### PR DESCRIPTION
Closes #39

## Summary

- Replaces `--no-bookmarks` with `--bookmarks` so bookmark generation is off by default, consistent with `--line-numbers` and `--page-numbers`
- Renames `ConvertOptions.noBookmarks` → `bookmarks` and flips the logic accordingly
- Updates README usage docs and all related tests

## Test plan

- [ ] `bun test` passes (136 tests)
- [ ] `--bookmarks` flag enables bookmarks in generated `.docx`
- [ ] Omitting `--bookmarks` produces headings with no bookmark elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)