### PR TITLE
fix: add contents: read permission to smoke-test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,8 @@ jobs:
   smoke-test:
     name: Smoke test (${{ matrix.artifact }})
     needs: [release, build]
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

- The `smoke-test` job was missing `permissions: contents: read`, causing `gh release download` to fail with "release not found" when trying to download assets from the draft release

## Test plan

- [ ] Merge and cut a patch release — smoke tests should pass and promote the draft to published

🤖 Generated with [Claude Code](https://claude.com/claude-code)