### PR TITLE
fix: smoke-test needs contents: write to download draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
     name: Smoke test (${{ matrix.artifact }})
     needs: [release, build]
     permissions:
-      contents: read
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

- `contents: read` is not enough for `gh release download` to see draft releases — GitHub's API only returns drafts to tokens with push access
- `contents: write` grants push-equivalent access, which is exactly what the `build` job already uses for `gh release upload` against the same draft
- The REST endpoint `/releases/tags/{tag}` returns 404 for drafts regardless of token; `gh release download` uses GraphQL first (which respects auth) but this only resolves with write-level access

## Why contents: read wasn't enough

From GitHub docs: *"Draft releases are only returned to authenticated users who have push access to the repository."* The Actions `GITHUB_TOKEN` with `contents: read` has no push access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)