### PR TITLE
fix: replace retired macos-13 runner, reset version to 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           - artifact: markdown-to-docx-darwin-arm64
             runner: macos-latest
           - artifact: markdown-to-docx-darwin-x64
-            runner: macos-13
+            runner: macos-latest
           - artifact: markdown-to-docx-windows-x64.exe
             runner: windows-latest
     runs-on: ${{ matrix.runner }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@josefaidt/markdown-to-docx",
-  "version": "0.5.0",
+  "version": "0.3.0",
   "bin": {
     "markdown-to-docx": "./bin/markdown-to-docx.ts"
   },


### PR DESCRIPTION
## Summary

- `macos-13` (Intel) is no longer available as a GitHub-hosted runner — replaces it with `macos-latest` (arm64), which can run the `darwin-x64` binary via Rosetta 2
- Resets `package.json` version back to `0.3.0` (last successfully published release) since v0.3.1–v0.5.0 all failed and remain as unpublished drafts

## After merging

The draft releases for v0.3.1, v0.3.2, v0.4.0, and v0.5.0 and their tags should be cleaned up before cutting a new release, otherwise `npm version` will try to bump from 0.3.0 to the next version correctly but the old draft tags will be stale noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)