### PR TITLE
fix: cleanup artifacts on failed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,34 @@ jobs:
           gh release edit "${{ needs.release.outputs.tag }}" \
             --repo "${{ github.repository }}" \
             --draft=false
+
+  cleanup:
+    name: Cleanup failed release
+    needs: [release, build, smoke-test]
+    if: always() && failure() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Revert version bump
+        run: |
+          git revert HEAD --no-edit
+          git push origin HEAD:main
+      - name: Delete tag
+        run: |
+          git push origin --delete "${{ needs.release.outputs.tag }}" || true
+      - name: Delete draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "${{ needs.release.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --yes || true


### PR DESCRIPTION
Closes #43

## Summary

- Adds a `cleanup` job to the release workflow that runs when `build` or `smoke-test` fails after `release` has already succeeded
- Reverts the version bump commit on `main`
- Deletes the git tag
- Deletes the draft GitHub release

## How it works

The job condition `always() && failure() && needs.release.result == 'success'` ensures it only runs when there's actually something to clean up — i.e., the `release` job pushed a version bump commit, tag, and draft release, but a downstream job failed before publishing.

The `|| true` on the delete steps prevents a secondary failure if those resources were already cleaned up manually.

## Test plan

- [ ] Trigger a release workflow and confirm it succeeds end-to-end (cleanup job should be skipped)
- [ ] Trigger a release workflow with a deliberate failure in `build` or `smoke-test` and confirm cleanup job reverts the version commit, deletes the tag, and deletes the draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)