### PR TITLE
fix: render fenced code blocks nested inside list items

### DIFF
--- a/lib/list.ts
+++ b/lib/list.ts
@@ -1,5 +1,6 @@
 import type { Tokens } from "marked"
-import { Paragraph, convertInchesToTwip } from "docx"
+import { Paragraph, TextRun, convertInchesToTwip } from "docx"
+import { highlightCode, isSupportedLang } from "./highlight"
 import { inlineTokensToRuns } from "./inline"
 
 const LIST_BULLET_INDENT = convertInchesToTwip(0.2)
@@ -12,12 +13,37 @@ export function listIndent(level: number) {
   return { left: textAt, hanging: textAt - bulletAt }
 }
 
-export function listItemsToParagraphs(
+async function codeTokenToParagraphs(token: Tokens.Generic): Promise<Paragraph[]> {
+  const codeText = (token["text"] as string | undefined) ?? ""
+  const codeLang = token["lang"] as string | undefined
+  if (isSupportedLang(codeLang)) {
+    const lines = await highlightCode(codeText, codeLang)
+    return lines.map(
+      (lineTokens) =>
+        new Paragraph({
+          style: "CodeBlock",
+          children: lineTokens.map(
+            (t) =>
+              new TextRun({
+                text: t.text,
+                font: "Consolas",
+                color: t.color,
+                bold: t.bold || undefined,
+                italics: t.italic || undefined,
+              }),
+          ),
+        }),
+    )
+  }
+  return codeText.split("\n").map((line) => new Paragraph({ text: line, style: "CodeBlock" }))
+}
+
+export async function listItemsToParagraphs(
   items: Tokens.Generic[],
   ordered: boolean,
   level: number,
   orderedRef: string,
-): Paragraph[] {
+): Promise<Paragraph[]> {
   const paragraphs: Paragraph[] = []
 
   for (const item of items) {
@@ -25,12 +51,15 @@ export function listItemsToParagraphs(
 
     const textTokens: Tokens.Generic[] = []
     const nestedLists: Tokens.Generic[] = []
+    const codeTokens: Tokens.Generic[] = []
 
     for (const t of (item["tokens"] as Tokens.Generic[] | undefined) ?? []) {
       if (t.type === "list") {
         nestedLists.push(t)
       } else if (t.type === "text" || t.type === "paragraph") {
         textTokens.push(t)
+      } else if (t.type === "code") {
+        codeTokens.push(t)
       }
     }
 
@@ -49,14 +78,18 @@ export function listItemsToParagraphs(
       }),
     )
 
+    for (const codeToken of codeTokens) {
+      paragraphs.push(...(await codeTokenToParagraphs(codeToken)))
+    }
+
     for (const nested of nestedLists) {
       paragraphs.push(
-        ...listItemsToParagraphs(
+        ...(await listItemsToParagraphs(
           (nested["items"] as Tokens.Generic[] | undefined) ?? [],
           (nested["ordered"] as boolean | undefined) ?? false,
           level + 1,
           orderedRef,
-        ),
+        )),
       )
     }
   }

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -505,6 +505,57 @@ describe("list inline formatting", () => {
   })
 })
 
+describe("nested code blocks in list items", () => {
+  const md = [
+    "1. item one",
+    "",
+    "2. item two",
+    "",
+    "   ```bash",
+    "   some-command",
+    "   ```",
+    "",
+    "3. item three",
+  ].join("\n")
+
+  test("list item text is present for all items", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain("item one")
+    expect(body).toContain("item two")
+    expect(body).toContain("item three")
+  })
+
+  test("fenced code block inside list item renders with CodeBlock style", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain('w:val="CodeBlock"')
+  })
+
+  test("fenced code block text is not stripped", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain("some-command")
+  })
+
+  test("plain (no lang) fenced code block inside list item renders CodeBlock style", async () => {
+    const plain = "1. item\n\n   ```\n   plain code\n   ```\n\n2. next"
+    const body = await bodyXml(plain)
+    expect(body).toContain('w:val="CodeBlock"')
+    expect(body).toContain("plain code")
+  })
+
+  test("highlighted fenced code block inside list item emits colored runs", async () => {
+    const highlighted = "1. item\n\n   ```typescript\n   const x = 1\n   ```\n\n2. next"
+    const body = await bodyXml(highlighted)
+    expect(body).toContain('w:val="D73A49"')
+  })
+
+  test("unordered list item with nested code block renders CodeBlock", async () => {
+    const bullet = "- item\n\n  ```\n  bullet-code\n  ```\n\n- next"
+    const body = await bodyXml(bullet)
+    expect(body).toContain('w:val="CodeBlock"')
+    expect(body).toContain("bullet-code")
+  })
+})
+
 describe("numbering level formats", () => {
   function orderedAbstractNum(numXml: string): string {
     const blocks = numXml.match(/<w:abstractNum\b[^>]*>[\s\S]*?<\/w:abstractNum>/g) ?? []

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -147,12 +147,12 @@ async function tokensToDocx(
           orderedRefs.push(orderedRef)
         }
         elements.push(
-          ...listItemsToParagraphs(
+          ...(await listItemsToParagraphs(
             (token["items"] as Tokens.Generic[] | undefined) ?? [],
             ordered,
             0,
             orderedRef,
-          ),
+          )),
         )
         break
       }


### PR DESCRIPTION
## Summary

- Fenced code blocks nested inside ordered/unordered list items were being silently dropped from the output docx
- `listItemsToParagraphs` now collects `code` tokens from list item children and renders them as `CodeBlock`-styled paragraphs with syntax highlighting
- The function is now async to support the existing `highlightCode` path

Fixes #47

## Test plan

- [ ] All 142 tests pass (`bun test`)
- [ ] Plain (no-lang) code blocks inside list items render with `CodeBlock` style
- [ ] Highlighted code blocks inside list items emit colored runs
- [ ] Both ordered and unordered list items with nested code blocks are covered
- [ ] Existing list tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)