### PR TITLE
fix: inline code uses prose color and is 1pt smaller than normal text

### DIFF
--- a/lib/document-styles.ts
+++ b/lib/document-styles.ts
@@ -17,6 +17,7 @@ interface FontSizes {
   heading4: number
   heading56: number
   codeBlock: number
+  inlineCode: number
   footerText: number
 }
 
@@ -30,6 +31,7 @@ function fontSizes(basePt: number): FontSizes {
     heading4: hp(basePt),
     heading56: hp(basePt),
     codeBlock: hp(basePt),
+    inlineCode: hp(basePt - 1),
     footerText: hp(10),
   }
 }
@@ -149,7 +151,7 @@ export function buildStyleOptions(
           name: "Inline Code",
           run: {
             font: "Consolas",
-            color: "555555",
+            size: sizes.inlineCode,
             shading: { type: ShadingType.CLEAR, color: "F2F2F2", fill: "F2F2F2" },
           },
         },

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -237,12 +237,14 @@ describe("inline formatting", () => {
     expect(body).toContain("foo()")
   })
 
-  test("InlineCode style has color 555555 to match code blocks", async () => {
+  test("InlineCode style has no explicit color (inherits prose color) and is 1pt smaller than normal", async () => {
     const { zip } = await buildDocx("`foo`")
     const stylesXml = await zip.file("word/styles.xml")!.async("string")
     const inlineCodeChunk =
       stylesXml.split(/<w:style\s/).find((c) => c.includes('"InlineCode"')) ?? ""
-    expect(inlineCodeChunk).toContain('w:val="555555"')
+    expect(inlineCodeChunk).not.toContain('w:val="555555"')
+    // base is 11pt (default); inlineCode is 10pt = 20 half-points
+    expect(inlineCodeChunk).toContain('w:val="20"')
   })
 
   test("`code#with-hash` renders as a single InlineCode run — not split at #", async () => {


### PR DESCRIPTION
Remove hardcoded color from InlineCode character style so it inherits the prose color from the surrounding paragraph. Add explicit font size of basePt-1 so inline code renders 1pt smaller than normal text.

Closes #46

Generated with [Claude Code](https://claude.ai/code)