### PR TITLE
fix: grey background, indent, and balanced spacing for nested list code blocks

### DIFF
--- a/.claude/skills/preview/assets/preview.md
+++ b/.claude/skills/preview/assets/preview.md
@@ -103,6 +103,29 @@ Back to a paragraph. Then an ordered list.
 
 Then another paragraph to close.
 
+## List Items with Nested Code Blocks (Issue #47)
+
+1. Install the dependency
+
+   ```bash
+   npm install some-package
+   ```
+
+2. Configure it in your project
+
+   ```typescript
+   import { configure } from "some-package"
+   configure({ option: true })
+   ```
+
+3. Run the build
+
+   ```bash
+   npm run build
+   ```
+
+4. Done
+
 ## List Separation (Issue #22)
 
 A bullet list followed by a blank line and then an ordered list — there should be visible space between them.

--- a/lib/list.ts
+++ b/lib/list.ts
@@ -1,5 +1,15 @@
 import type { Tokens } from "marked"
-import { Paragraph, TextRun, convertInchesToTwip } from "docx"
+import {
+  BorderStyle,
+  Paragraph,
+  ShadingType,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+  convertInchesToTwip,
+} from "docx"
 import { highlightCode, isSupportedLang } from "./highlight"
 import { inlineTokensToRuns } from "./inline"
 
@@ -13,29 +23,62 @@ export function listIndent(level: number) {
   return { left: textAt, hanging: textAt - bulletAt }
 }
 
-async function codeTokenToParagraphs(token: Tokens.Generic): Promise<Paragraph[]> {
+async function codeTokenToTable(token: Tokens.Generic, level: number): Promise<Table> {
   const codeText = (token["text"] as string | undefined) ?? ""
   const codeLang = token["lang"] as string | undefined
-  if (isSupportedLang(codeLang)) {
-    const lines = await highlightCode(codeText, codeLang)
-    return lines.map(
-      (lineTokens) =>
-        new Paragraph({
-          style: "CodeBlock",
-          children: lineTokens.map(
-            (t) =>
-              new TextRun({
-                text: t.text,
-                font: "Consolas",
-                color: t.color,
-                bold: t.bold || undefined,
-                italics: t.italic || undefined,
-              }),
-          ),
-        }),
-    )
-  }
-  return codeText.split("\n").map((line) => new Paragraph({ text: line, style: "CodeBlock" }))
+  const codeLines = isSupportedLang(codeLang)
+    ? (await highlightCode(codeText, codeLang)).map(
+        (lineTokens) =>
+          new Paragraph({
+            style: "CodeBlock",
+            children: lineTokens.map(
+              (t) =>
+                new TextRun({
+                  text: t.text,
+                  font: "Consolas",
+                  color: t.color,
+                  bold: t.bold || undefined,
+                  italics: t.italic || undefined,
+                }),
+            ),
+          }),
+      )
+    : codeText.split("\n").map((line) => new Paragraph({ text: line, style: "CodeBlock" }))
+
+  return new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    indent: { size: listIndent(level).left, type: WidthType.DXA },
+    borders: {
+      top: { style: BorderStyle.NONE, size: 0 },
+      bottom: { style: BorderStyle.NONE, size: 0 },
+      left: { style: BorderStyle.NONE, size: 0 },
+      right: { style: BorderStyle.NONE, size: 0 },
+      insideHorizontal: { style: BorderStyle.NONE, size: 0 },
+      insideVertical: { style: BorderStyle.NONE, size: 0 },
+    },
+    rows: [
+      new TableRow({
+        children: [
+          new TableCell({
+            children: codeLines,
+            shading: { type: ShadingType.CLEAR, color: "F6F8FA", fill: "F6F8FA" },
+            margins: {
+              top: convertInchesToTwip(0.1),
+              bottom: convertInchesToTwip(0.1),
+              left: convertInchesToTwip(0.15),
+              right: convertInchesToTwip(0.15),
+            },
+            borders: {
+              top: { style: BorderStyle.NONE, size: 0 },
+              bottom: { style: BorderStyle.NONE, size: 0 },
+              left: { style: BorderStyle.NONE, size: 0 },
+              right: { style: BorderStyle.NONE, size: 0 },
+            },
+          }),
+        ],
+      }),
+    ],
+  })
 }
 
 export async function listItemsToParagraphs(
@@ -43,8 +86,8 @@ export async function listItemsToParagraphs(
   ordered: boolean,
   level: number,
   orderedRef: string,
-): Promise<Paragraph[]> {
-  const paragraphs: Paragraph[] = []
+): Promise<Array<Paragraph | Table>> {
+  const elements: Array<Paragraph | Table> = []
 
   for (const item of items) {
     if (item["type"] !== "list_item") continue
@@ -67,7 +110,7 @@ export async function listItemsToParagraphs(
       (t) => (t["tokens"] as Tokens.Generic[] | undefined) ?? (t["text"] ? [t] : []),
     )
 
-    paragraphs.push(
+    elements.push(
       new Paragraph({
         style: "ListItem",
         children: inlineTokensToRuns(inlineTokens),
@@ -79,11 +122,19 @@ export async function listItemsToParagraphs(
     )
 
     for (const codeToken of codeTokens) {
-      paragraphs.push(...(await codeTokenToParagraphs(codeToken)))
+      elements.push(await codeTokenToTable(codeToken, level))
+      // Word has no conditional next-sibling spacing, so we add an explicit spacer
+      // to balance the gap after the table with the ListItem `after: 160` before it.
+      elements.push(
+        new Paragraph({
+          children: [new TextRun({ size: 12 })],
+          spacing: { before: 0, after: 160, line: 160, lineRule: "exact" as const },
+        }),
+      )
     }
 
     for (const nested of nestedLists) {
-      paragraphs.push(
+      elements.push(
         ...(await listItemsToParagraphs(
           (nested["items"] as Tokens.Generic[] | undefined) ?? [],
           (nested["ordered"] as boolean | undefined) ?? false,
@@ -94,5 +145,5 @@ export async function listItemsToParagraphs(
     }
   }
 
-  return paragraphs
+  return elements
 }

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -537,6 +537,22 @@ describe("nested code blocks in list items", () => {
     expect(body).toContain("some-command")
   })
 
+  test("fenced code block inside list item has grey background shading", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain('w:fill="F6F8FA"')
+  })
+
+  test("fenced code block inside list item is indented to match list level", async () => {
+    const body = await bodyXml(md)
+    // level 0: LIST_TEXT_INDENT = convertInchesToTwip(0.45) = 648 twips
+    expect(body).toContain('w:w="648"')
+  })
+
+  test("spacer paragraph after nested code block has after: 160 spacing", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain('w:after="160"')
+  })
+
   test("plain (no lang) fenced code block inside list item renders CodeBlock style", async () => {
     const plain = "1. item\n\n   ```\n   plain code\n   ```\n\n2. next"
     const body = await bodyXml(plain)


### PR DESCRIPTION
## Summary

Follows up on #48 with visual fixes for nested code blocks inside list items.

- **Background**: wraps the code in the same borderless `Table` + `F6F8FA` grey shading as top-level code blocks (the original fix used bare `CodeBlock` paragraphs with no shading)
- **Indentation**: sets `tblInd` on the table to match the list item's indent level so the code block aligns under its parent item
- **Spacing**: adds an explicit spacer paragraph (`after: 160`) after each code table to balance the visual gap — the gap before the code block comes naturally from `ListItem`'s `after: 160` style spacing

### Spacing note

Word paragraph spacing has no conditional "next-sibling" awareness, so it's not possible to make the `ListItem` style apply different `after` spacing only when followed by a nested code block. The explicit spacer paragraph after each code table is the correct workaround — `ListItem`'s `after: 160` covers the pre-code gap; the spacer covers the post-code gap. This keeps the spacing targeted and doesn't affect normal list item spacing.

## Test plan

- [ ] All 145 tests pass (`bun test`)
- [ ] Nested code block has grey `F6F8FA` background
- [ ] Nested code block is indented to align under its list item
- [ ] Spacing before and after the nested code block is visually balanced
- [ ] Syntax highlighting still works inside nested code blocks
- [ ] Existing list and code block tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)