### PR TITLE
fix: balance post-code-block spacer in nested list code blocks

### DIFF
--- a/lib/list.ts
+++ b/lib/list.ts
@@ -128,7 +128,7 @@ export async function listItemsToParagraphs(
       elements.push(
         new Paragraph({
           children: [new TextRun({ size: 12 })],
-          spacing: { before: 0, after: 160, line: 160, lineRule: "exact" as const },
+          spacing: { before: 0, after: 0, line: 160, lineRule: "exact" as const },
         }),
       )
     }

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -548,9 +548,10 @@ describe("nested code blocks in list items", () => {
     expect(body).toContain('w:w="648"')
   })
 
-  test("spacer paragraph after nested code block has after: 160 spacing", async () => {
+  test("spacer paragraph after nested code block uses exact 160-twip line height with no after spacing", async () => {
     const body = await bodyXml(md)
-    expect(body).toContain('w:after="160"')
+    expect(body).toContain('w:lineRule="exact"')
+    expect(body).toContain('w:line="160"')
   })
 
   test("plain (no lang) fenced code block inside list item renders CodeBlock style", async () => {


### PR DESCRIPTION
## Summary

The spacer paragraph added after a nested code block table in #50 used `after: 160`, which caused the post-table gap to be ~320 twips (160 line height + 160 after) — roughly twice the pre-table gap of 160 twips from `ListItem`'s `after` spacing.

Drops `after` to `0` so only the 160-twip exact line height contributes, making both sides of the code block visually balanced.

### Spacing note (carried forward from #50)

Word paragraph spacing has no conditional "next-sibling" awareness, so it's not possible to make the `ListItem` style apply different `after` spacing only when followed by a nested code block. The explicit spacer paragraph is the correct workaround — `ListItem`'s `after: 160` covers the pre-code gap; the spacer's line height covers the post-code gap.

## Test plan

- [ ] All 145 tests pass (`bun test`)
- [ ] Spacing before and after the nested code block is visually balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)