### PR TITLE
fix: ignore HTML comments and trim leading whitespace to prevent blank paragraphs before first heading

### DIFF
--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -146,6 +146,23 @@ describe("frontmatter", () => {
     const body = await bodyXml("# Hello")
     expect(body).toContain("Hello")
   })
+
+  test("HTML comment between frontmatter and first heading does not add an empty paragraph before the heading", async () => {
+    const md = "---\ntitle: A New Doc\n---\n\n<!-- internal comment -->\n\n# The First Heading"
+    const body = await bodyXml(md)
+    expect(body).not.toContain("internal comment")
+    // Only one <w:p element should exist — the heading itself (no preceding empty paragraph)
+    const paragraphs = body.match(/<w:p[ >]/g) ?? []
+    expect(paragraphs).toHaveLength(1)
+  })
+
+  test("HTML comment mid-document is silently ignored", async () => {
+    const md = "# Heading\n\n<!-- a comment -->\n\nSome text."
+    const body = await bodyXml(md)
+    expect(body).not.toContain("a comment")
+    expect(body).toContain("Heading")
+    expect(body).toContain("Some text.")
+  })
 })
 
 describe("headings", () => {

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -292,6 +292,9 @@ async function tokensToDocx(
         break
       }
 
+      case "html":
+        break
+
       case "space": {
         if (prevTokenType === "list" && nextTokenType === "list") {
           elements.push(
@@ -341,7 +344,7 @@ export async function convertMarkdownToDocx(
 ): Promise<Document> {
   const content = await Bun.file(markdownPath).text()
   const { body, data } = parseFrontmatter(content)
-  const tokens = marked.lexer(body) as Tokens.Generic[]
+  const tokens = marked.lexer(body.trimStart()) as Tokens.Generic[]
   const { elements, orderedRefs } = await tokensToDocx(tokens, markdownPath, options.bookmarks)
 
   // CLI flags take precedence; frontmatter.title is the fallback for headerLabel


### PR DESCRIPTION
HTML comments (`<!-- ... -->`) were being parsed as `html` tokens by marked and falling through to the `default` case in `tokensToDocx`. Because `token["text"]` is truthy for the comment content, an empty `new Paragraph({ children: [] })` was being pushed, creating a blank line before the first heading.

Fixes #54

Generated with [Claude Code](https://claude.ai/code)