### PR TITLE
feat: add support for footnotes/citations

### DIFF
--- a/.claude/skills/preview/assets/preview.md
+++ b/.claude/skills/preview/assets/preview.md
@@ -193,3 +193,13 @@ A standalone block image:
 ![Goofy Llama](./goofy-llama.jpg)
 
 An image inline with text: here is the llama ![Goofy Llama](./goofy-llama.jpg) mid-sentence.
+
+## Footnotes (Issue #53)
+
+This is some text with a citation.[^1] This is another sentence.[^2] And here is a third reference.[^3]
+
+[^1] [Some Link to Another Article](https://example.com)
+
+[^2] [Another Article Link](https://example.com)
+
+[^3] Plain text footnote without a hyperlink, just to verify mixed content renders correctly.

--- a/lib/document-styles.ts
+++ b/lib/document-styles.ts
@@ -19,6 +19,8 @@ interface FontSizes {
   codeBlock: number
   inlineCode: number
   footerText: number
+  footnote: number
+  footnoteRef: number
 }
 
 function fontSizes(basePt: number): FontSizes {
@@ -33,6 +35,8 @@ function fontSizes(basePt: number): FontSizes {
     codeBlock: hp(basePt),
     inlineCode: hp(basePt - 1),
     footerText: hp(10),
+    footnote: hp(basePt - 2),
+    footnoteRef: hp(basePt - 4),
   }
 }
 
@@ -139,6 +143,13 @@ export function buildStyleOptions(
           paragraph: { spacing: { before: 0, after: 0 } },
           run: { size: sizes.footerText, color: "888888" },
         },
+        {
+          id: "Footnote",
+          name: "Footnote",
+          basedOn: "Normal",
+          run: { color: "888888" },
+          paragraph: { spacing: { before: 60, after: 60 } },
+        },
       ],
       characterStyles: [
         {
@@ -154,6 +165,11 @@ export function buildStyleOptions(
             size: sizes.inlineCode,
             shading: { type: ShadingType.CLEAR, color: "F2F2F2", fill: "F2F2F2" },
           },
+        },
+        {
+          id: "FootnoteRef",
+          name: "Footnote Reference",
+          run: { size: sizes.footnoteRef, position: 8 },
         },
         {
           id: "Hyperlink",

--- a/lib/footnote.ts
+++ b/lib/footnote.ts
@@ -1,0 +1,57 @@
+import type { MarkedExtension, Tokens } from "marked"
+import { Lexer } from "marked"
+
+export interface FootnoteRefToken {
+  type: "footnote_ref"
+  raw: string
+  label: string
+}
+
+export interface FootnoteDefToken {
+  type: "footnote_def"
+  raw: string
+  label: string
+  tokens: Tokens.Generic[]
+}
+
+export const footnote: MarkedExtension = {
+  extensions: [
+    {
+      name: "footnote_def",
+      level: "block",
+      start(src) {
+        return src.match(/^\[\^\d+\]\s/)?.index ?? -1
+      },
+      tokenizer(src) {
+        const match = /^\[\^(\d+)\]\s(.+)/.exec(src)
+        if (!match) return undefined
+        const label = match[1]!
+        const content = match[2]!
+        const tokens = Lexer.lexInline(content) as Tokens.Generic[]
+        return {
+          type: "footnote_def",
+          raw: match[0],
+          label,
+          tokens,
+        } satisfies FootnoteDefToken
+      },
+      childTokens: ["tokens"],
+    },
+    {
+      name: "footnote_ref",
+      level: "inline",
+      start(src) {
+        return src.match(/\[\^\d+\]/)?.index ?? -1
+      },
+      tokenizer(src) {
+        const match = /^\[\^(\d+)\]/.exec(src)
+        if (!match) return undefined
+        return {
+          type: "footnote_ref",
+          raw: match[0],
+          label: match[1]!,
+        } satisfies FootnoteRefToken
+      },
+    },
+  ],
+}

--- a/lib/inline.ts
+++ b/lib/inline.ts
@@ -113,6 +113,11 @@ export function inlineTokensToRuns(
         }
         break
       }
+      case "footnote_ref": {
+        const label = token["label"] as string | undefined
+        runs.push(new TextRun({ text: label ?? "", style: "FootnoteRef", ...ctx }))
+        break
+      }
       case "br":
         runs.push(new TextRun({ break: 1 }))
         break

--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -802,3 +802,66 @@ describe("header", () => {
     expect(header).not.toContain("FM Title")
   })
 })
+
+describe("footnotes", () => {
+  const md = [
+    "Some text with a citation.[^1] Another sentence.[^2]",
+    "",
+    "[^1] [Some Link](https://example.com)",
+    "",
+    "[^2] Plain text footnote",
+  ].join("\n")
+
+  test("footnote ref in prose renders as FootnoteRef character style", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain('w:val="FootnoteRef"')
+  })
+
+  test("footnote ref renders the label number as text", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain(">1<")
+    expect(body).toContain(">2<")
+  })
+
+  test("footnote definition uses Footnote paragraph style", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain('w:val="Footnote"')
+  })
+
+  test("footnote definition label renders as FootnoteRef character style", async () => {
+    const body = await bodyXml(md)
+    const footnoteChunk = body.slice(body.indexOf('w:val="Footnote"'))
+    expect(footnoteChunk).toContain('w:val="FootnoteRef"')
+  })
+
+  test("footnote definition with hyperlink renders as hyperlink", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain("<w:hyperlink")
+    expect(body).toContain("Some Link")
+  })
+
+  test("footnote definition plain text renders the text", async () => {
+    const body = await bodyXml(md)
+    expect(body).toContain("Plain text footnote")
+  })
+
+  test("FootnoteRef character style has size and position set", async () => {
+    const { zip } = await buildDocx(md)
+    const stylesXml = await zip.file("word/styles.xml")!.async("string")
+    const chunk = stylesXml.split(/<w:style\s/).find((c) => c.includes('"FootnoteRef"')) ?? ""
+    expect(chunk).toContain("<w:sz ")
+    expect(chunk).toContain("<w:position ")
+  })
+
+  test("FootnoteRef size scales with fontSize option", async () => {
+    const { zip: zip10 } = await buildDocx(md, { fontSize: 10 })
+    const { zip: zip12 } = await buildDocx(md, { fontSize: 12 })
+    const styles10 = await zip10.file("word/styles.xml")!.async("string")
+    const styles12 = await zip12.file("word/styles.xml")!.async("string")
+    const size10 = styles10.split(/<w:style\s/).find((c) => c.includes('"FootnoteRef"'))
+    const size12 = styles12.split(/<w:style\s/).find((c) => c.includes('"FootnoteRef"'))
+    const sz10 = parseInt(size10?.match(/<w:sz w:val="(\d+)"/)?.[1] ?? "0", 10)
+    const sz12 = parseInt(size12?.match(/<w:sz w:val="(\d+)"/)?.[1] ?? "0", 10)
+    expect(sz12).toBeGreaterThan(sz10)
+  })
+})

--- a/lib/markdown-to-docx.ts
+++ b/lib/markdown-to-docx.ts
@@ -23,12 +23,15 @@ import {
 } from "docx"
 import { marked } from "marked"
 import { buildNumbering, buildStyleOptions } from "./document-styles"
+import { footnote } from "./footnote"
 import { parseFrontmatter } from "./frontmatter"
 import { highlightCode, isSupportedLang } from "./highlight"
 import { loadImage } from "./image"
 import { headingSlug, inlineTokensToRuns } from "./inline"
 import { listItemsToParagraphs } from "./list"
 import { buildTable } from "./table"
+
+marked.use(footnote)
 
 const HEADING_STYLES: Record<number, string> = {
   1: "Heading1",
@@ -277,6 +280,22 @@ async function tokensToDocx(
             }),
           )
         }
+        break
+      }
+
+      case "footnote_def": {
+        const label = token["label"] as string | undefined
+        const inlineTokens = (token["tokens"] as Tokens.Generic[] | undefined) ?? []
+        elements.push(
+          new Paragraph({
+            style: "Footnote",
+            children: [
+              new TextRun({ text: `${label ?? ""}`, style: "FootnoteRef" }),
+              new TextRun({ text: " " }),
+              ...inlineTokensToRuns(inlineTokens),
+            ],
+          }),
+        )
         break
       }
 


### PR DESCRIPTION
Closes #53

## Summary

- Adds a `footnote` marked extension (`lib/footnote.ts`) exposing `FootnoteRefToken` and `FootnoteDefToken` — registered at the call site with `marked.use(footnote)`
- Inline `[^N]` references render as small raised superscript via a new `FootnoteRef` character style (scales with `--font-size`, same pattern as `InlineCode`)
- Footnote definitions (`[^N] content`) render as `Footnote` paragraph style — lighter color, normal font size — with the label number as a matching `FootnoteRef` superscript
- 8 new tests covering ref rendering, definition rendering, hyperlinks in footnotes, style presence, and font-size scaling

## Test plan

- [ ] `bun test` passes (109 tests)
- [ ] Preview `.docx` shows superscript numbers in prose and matching superscript labels preceding footnote text at normal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)