### PR TITLE
docs: add known limitations section for Word Online rendering differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ bunx skills add josefaidt/markdown-to-docx
 The following features render correctly in the Word desktop app but behave differently in Word Online (SharePoint):
 
 - **Footnote superscripts**: The raised superscript style on footnote reference numbers is ignored by Word Online — numbers appear inline at normal size.
-- **Footer page numbers**: The right-aligned tab stop used to position page numbers in the footer is not honoured by Word Online, so the page number does not align to the right margin.
+- **Footer page numbers**: The right-aligned tab stop used to position page numbers in the footer is not honored by Word Online, so the page number does not align to the right margin.
 - **Line number styles**: Word Online always renders line numbers in Times New Roman regardless of the font set in the `lineNumber` character style.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ Install the `convert-markdown-to-docx` skill into your coding agent:
 ```sh
 bunx skills add josefaidt/markdown-to-docx
 ```
+
+## Known Limitations
+
+The following features render correctly in the Word desktop app but behave differently in Word Online (SharePoint):
+
+- **Footnote superscripts**: The raised superscript style on footnote reference numbers is ignored by Word Online — numbers appear inline at normal size.
+- **Footer page numbers**: The right-aligned tab stop used to position page numbers in the footer is not honoured by Word Online, so the page number does not align to the right margin.
+- **Line number styles**: Word Online always renders line numbers in Times New Roman regardless of the font set in the `lineNumber` character style.


### PR DESCRIPTION
## Summary

Adds a **Known Limitations** section to the README documenting three features that render correctly in Word desktop but behave differently in Word Online / SharePoint:

- Footnote superscripts ignored (appear inline at normal size)
- Footer page numbers don't right-align (tab stop not honoured)
- Line numbers always render in Times New Roman regardless of style

## Test plan

- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)