### PR TITLE
feat: support strikethrough

### DIFF
--- a/lib/inline.ts
+++ b/lib/inline.ts
@@ -7,6 +7,7 @@ export type InlineChild = TextRun | ExternalHyperlink | InternalHyperlink | Imag
 interface InlineCtx {
   bold?: boolean
   italics?: boolean
+  strike?: boolean
   useTemplate?: boolean
 }
 
@@ -58,6 +59,11 @@ export function inlineTokensToRuns(
       case "em":
         runs.push(
           ...inlineTokensToRuns(children ?? [], { ...ctx, italics: true }, images, useTemplate),
+        )
+        break
+      case "del":
+        runs.push(
+          ...inlineTokensToRuns(children ?? [], { ...ctx, strike: true }, images, useTemplate),
         )
         break
       case "codespan":


### PR DESCRIPTION
Add strikethrough support for `~~text~~` markdown syntax.

Handles the `del` token emitted by marked for GFM strikethrough, mapping it to `TextRun`'s `strike` property. Nested formatting like `~~**bold**~~` works automatically.

Closes #60

Generated with [Claude Code](https://claude.ai/code)