### PR TITLE
feat: support GFM strikethrough (~~text~~)

### DIFF
--- a/lib/inline.test.ts
+++ b/lib/inline.test.ts
@@ -53,6 +53,26 @@ describe("inlineTokensToRuns", () => {
     expect(runs.every((r) => r instanceof TextRun)).toBe(true)
   })
 
+  test("~~strike~~ → single TextRun with strike=true", () => {
+    const runs = parseInline("~~strike~~")
+    expect(runs).toHaveLength(1)
+    expect(runs[0]).toBeInstanceOf(TextRun)
+    const strike = (runs[0] as any).root.find(
+      (n: any) => n && typeof n === "object" && "root" in n && n.rootKey === "w:rPr",
+    )
+    const hasStrike = JSON.stringify(strike).includes("w:strike")
+    expect(hasStrike).toBe(true)
+  })
+
+  test("~~**bold strike**~~ — nested strong inside del → single TextRun with bold + strike", () => {
+    const runs = parseInline("~~**bold strike**~~")
+    expect(runs).toHaveLength(1)
+    expect(runs[0]).toBeInstanceOf(TextRun)
+    const serialized = JSON.stringify(runs[0])
+    expect(serialized).toContain("w:strike")
+    expect(serialized).toContain("w:b")
+  })
+
   test("[**bold**](url) — nested strong in link → ExternalHyperlink", () => {
     const runs = parseInline("[**bold link**](https://example.com)")
     expect(runs).toHaveLength(1)

--- a/lib/inline.test.ts
+++ b/lib/inline.test.ts
@@ -73,6 +73,46 @@ describe("inlineTokensToRuns", () => {
     expect(serialized).toContain("w:b")
   })
 
+  test("~~*italic strike*~~ — nested em inside del → italic + strike", () => {
+    const runs = parseInline("~~*italic strike*~~")
+    expect(runs).toHaveLength(1)
+    const serialized = JSON.stringify(runs[0])
+    expect(serialized).toContain("w:strike")
+    expect(serialized).toContain("w:i")
+  })
+
+  test("*~~italic strike~~* — del inside em → italic + strike", () => {
+    const runs = parseInline("*~~italic strike~~*")
+    expect(runs).toHaveLength(1)
+    const serialized = JSON.stringify(runs[0])
+    expect(serialized).toContain("w:strike")
+    expect(serialized).toContain("w:i")
+  })
+
+  test("~~`code strike`~~ — codespan inside del → strike flag carries through", () => {
+    const runs = parseInline("~~`code strike`~~")
+    expect(runs).toHaveLength(1)
+    expect(runs[0]).toBeInstanceOf(TextRun)
+    const serialized = JSON.stringify(runs[0])
+    expect(serialized).toContain("w:strike")
+  })
+
+  test("`~~not strike~~` — tildes inside codespan are literal (no formatting)", () => {
+    const runs = parseInline("`~~not strike~~`")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("~~not strike~~")
+  })
+
+  test("***~~all three~~*** — bold + italic + strike compose", () => {
+    const runs = parseInline("***~~all three~~***")
+    expect(runs).toHaveLength(1)
+    const serialized = JSON.stringify(runs[0])
+    expect(serialized).toContain("w:strike")
+    expect(serialized).toContain("w:b")
+    expect(serialized).toContain("w:i")
+  })
+
   test("[**bold**](url) — nested strong in link → ExternalHyperlink", () => {
     const runs = parseInline("[**bold link**](https://example.com)")
     expect(runs).toHaveLength(1)

--- a/lib/inline.ts
+++ b/lib/inline.ts
@@ -7,6 +7,7 @@ export type InlineChild = TextRun | ExternalHyperlink | InternalHyperlink | Imag
 interface InlineCtx {
   bold?: boolean
   italics?: boolean
+  strike?: boolean
   useTemplate?: boolean
 }
 
@@ -58,6 +59,11 @@ export function inlineTokensToRuns(
       case "em":
         runs.push(
           ...inlineTokensToRuns(children ?? [], { ...ctx, italics: true }, images, useTemplate),
+        )
+        break
+      case "del":
+        runs.push(
+          ...inlineTokensToRuns(children ?? [], { ...ctx, strike: true }, images, useTemplate),
         )
         break
       case "codespan":


### PR DESCRIPTION
Maps marked's `del` token to TextRun's `strike` property, mirroring the existing handling for `strong` and `em` so nested formatting like `~~**bold strike**~~` composes correctly.

Refs #60