### PR TITLE
fix: decode HTML entities (e.g. `&nbsp;`) in inline text

### DIFF
--- a/lib/inline.test.ts
+++ b/lib/inline.test.ts
@@ -85,6 +85,55 @@ describe("inlineTokensToRuns", () => {
     expect(wt.root[1]).toBe("foo \u2014 bar")
   })
 
+  test("&nbsp; is decoded to non-breaking space (U+00A0)", () => {
+    const runs = parseInline("hello&nbsp;world")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("hello world")
+  })
+
+  test("multiple &nbsp; entities are all decoded", () => {
+    const runs = parseInline("a&nbsp;&nbsp;b")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("a  b")
+  })
+
+  test("&#160; numeric entity is decoded to non-breaking space", () => {
+    const runs = parseInline("foo&#160;bar")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("foo bar")
+  })
+
+  test("&#xA0; hex entity is decoded to non-breaking space", () => {
+    const runs = parseInline("foo&#xA0;bar")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("foo bar")
+  })
+
+  test("&amp; is decoded to ampersand", () => {
+    const runs = parseInline("Tom&amp;Jerry")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("Tom&Jerry")
+  })
+
+  test("&lt; and &gt; are decoded to angle brackets", () => {
+    const runs = parseInline("&lt;div&gt;")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("<div>")
+  })
+
+  test("unknown entities are left as-is", () => {
+    const runs = parseInline("&fakething;")
+    expect(runs).toHaveLength(1)
+    const wt = (runs[0] as TextRun as any).root.find((n: any) => n.rootKey === "w:t")
+    expect(wt.root[1]).toBe("&fakething;")
+  })
+
   test("empty token list → empty array", () => {
     expect(inlineTokensToRuns([])).toHaveLength(0)
   })

--- a/lib/inline.ts
+++ b/lib/inline.ts
@@ -10,8 +10,44 @@ interface InlineCtx {
   useTemplate?: boolean
 }
 
+const NAMED_ENTITIES: Record<string, string> = {
+  nbsp: "\u00a0",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  copy: "\u00a9",
+  reg: "\u00ae",
+  trade: "\u2122",
+  mdash: "\u2014",
+  ndash: "\u2013",
+  hellip: "\u2026",
+  laquo: "\u00ab",
+  raquo: "\u00bb",
+  lsquo: "\u2018",
+  rsquo: "\u2019",
+  ldquo: "\u201c",
+  rdquo: "\u201d",
+  bull: "\u2022",
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(#x?[0-9a-fA-F]+|\w+);/g, (match, entity: string) => {
+    if (entity.startsWith("#x") || entity.startsWith("#X")) {
+      const code = parseInt(entity.slice(2), 16)
+      return isNaN(code) ? match : String.fromCodePoint(code)
+    }
+    if (entity.startsWith("#")) {
+      const code = parseInt(entity.slice(1), 10)
+      return isNaN(code) ? match : String.fromCodePoint(code)
+    }
+    return NAMED_ENTITIES[entity] ?? match
+  })
+}
+
 function applyTypography(text: string): string {
-  return text.replace(/--/g, "\u2014")
+  return decodeHtmlEntities(text).replace(/--/g, "\u2014")
 }
 
 // Word silently truncates bookmark names to 40 characters, so we enforce the


### PR DESCRIPTION
Fixes #67

## Problem
Marked leaves HTML entities like `&nbsp;`, `&amp;`, `&lt;` undecoded in token text, so they rendered literally (e.g. `&nbsp;`) in the `.docx` output instead of as an actual non-breaking space.

## Solution
Added a `decodeHtmlEntities()` step inside `applyTypography()` — the single point all inline text passes through. It handles:

- **Named entities** — `&nbsp;` → U+00A0, `&amp;` → `&`, `&lt;`/`&gt;`, plus common typographic entities (`&mdash;`, `&copy;`, curly quotes, etc.)
- **Decimal numeric** — `&#160;` → U+00A0
- **Hex numeric** — `&#xA0;` → U+00A0
- **Unknown entities** — left untouched

Codespans (`` `code` ``) are unaffected since they use `rawText` directly and bypass `applyTypography`.

## Tests
Added 7 tests to `lib/inline.test.ts` covering `&nbsp;`, repeated `&nbsp;`, decimal/hex numeric refs, `&amp;`, `&lt;`/`&gt;`, and unknown-entity passthrough. Full suite: 168 → 175 passing.