### PR TITLE
fix: emit valid table grid so tables render in Word Online

### DIFF
--- a/lib/markdown-to-docx.test.ts
+++ b/lib/markdown-to-docx.test.ts
@@ -461,10 +461,28 @@ describe("tables", () => {
     expect(body).toContain("bar")
   })
 
-  test("table uses full-width percentage layout", async () => {
+  test("table is full-width and autofit so it inherits the page width", async () => {
     const body = await bodyXml("| A |\n|---|\n| x |")
+    // Percentage width + autofit lets Word distribute columns to fill whatever
+    // page size and margins are in effect, rather than a hardcoded width.
     expect(body).toContain('w:type="pct"')
-    expect(body).toContain('w:w="5000"')
+    expect(body).toContain('<w:tblLayout w:type="autofit"/>')
+  })
+
+  test("table grid columns are non-degenerate and track content", async () => {
+    const body = await bodyXml(
+      "| # | Condition | Response |\n| :-- | :-- | :-- |\n| 1 | a running deployment | passes through |",
+    )
+    const grid = body.match(/<w:tblGrid>(.*?)<\/w:tblGrid>/s)?.[1] ?? ""
+    const cols = [...grid.matchAll(/<w:gridCol w:w="(\d+)"\/>/g)].map((m) => Number(m[1]))
+    expect(cols).toHaveLength(3)
+    // No degenerate placeholder widths (the old bug emitted identical 100-twip
+    // columns that Word Online could not reconcile with the declared width).
+    expect(cols.every((w) => w > 0)).toBe(true)
+    expect(new Set(cols).size).toBeGreaterThan(1)
+    // The content-heavy columns start wider than the "#" column.
+    expect(cols[1]!).toBeGreaterThan(cols[0]!)
+    expect(cols[2]!).toBeGreaterThan(cols[0]!)
   })
 })
 

--- a/lib/table.ts
+++ b/lib/table.ts
@@ -1,5 +1,13 @@
 import type { Tokens } from "marked"
-import { AlignmentType, ImportedXmlComponent, Paragraph, Table, TableCell, TableRow } from "docx"
+import {
+  AlignmentType,
+  Paragraph,
+  Table,
+  TableCell,
+  TableLayoutType,
+  TableRow,
+  WidthType,
+} from "docx"
 import { inlineTokensToRuns } from "./inline"
 
 interface ParsedTableCell {
@@ -9,8 +17,45 @@ interface ParsedTableCell {
   align: "center" | "left" | "right" | null
 }
 
+/**
+ * Base grid-column hint every column gets, plus per-character growth. These are
+ * proportional hints for an autofit table, not absolute widths, so the exact
+ * scale is immaterial — only the ratios matter. The base ensures even a single
+ * narrow column stays a legible width relative to its neighbours.
+ */
+const COLUMN_BASE_TWIP = 300
+const PER_CHAR_TWIP = 100
+
+/**
+ * Compute proportional column-width hints for the table grid, weighted by the
+ * longest cell text in each column. These are hints only: the table is emitted
+ * as a full-width autofit table, so Word distributes the columns to fill the
+ * page (whatever its size and margins) starting from these ratios.
+ */
+function computeColumnWidths(charCounts: number[]): number[] {
+  return charCounts.map((c) => COLUMN_BASE_TWIP + c * PER_CHAR_TWIP)
+}
+
 export function buildTable(token: Tokens.Generic): Table {
-  const rows: TableRow[] = []
+  const header = (token["header"] as ParsedTableCell[] | undefined) ?? []
+  const bodyRows = (token["rows"] as ParsedTableCell[][] | undefined) ?? []
+
+  const columnCount = Math.max(header.length, ...bodyRows.map((r) => r.length), 0)
+
+  // Weight each column by the longest cell text it contains (header + body),
+  // so the grid tracks content without depending on how the author spaced the
+  // markdown pipes.
+  const chars: number[] = Array.from({ length: columnCount }, () => 0)
+  const measure = (cells: ParsedTableCell[]) => {
+    for (let i = 0; i < cells.length; i++) {
+      const len = cells[i]?.text.length ?? 0
+      if (len > (chars[i] ?? 0)) chars[i] = len
+    }
+  }
+  measure(header)
+  for (const row of bodyRows) measure(row)
+
+  const columnWidths = computeColumnWidths(chars)
 
   const cellParagraph = (cell: ParsedTableCell, bold = false) =>
     new Paragraph({
@@ -25,8 +70,8 @@ export function buildTable(token: Tokens.Generic): Table {
       children: [cellParagraph(cell, bold)],
     })
 
-  const header = token["header"] as ParsedTableCell[] | undefined
-  if (header && header.length > 0) {
+  const rows: TableRow[] = []
+  if (header.length > 0) {
     rows.push(
       new TableRow({
         children: header.map((cell) => tableCell(cell, true)),
@@ -34,32 +79,21 @@ export function buildTable(token: Tokens.Generic): Table {
       }),
     )
   }
-
-  for (const row of (token["rows"] as ParsedTableCell[][] | undefined) ?? []) {
-    rows.push(
-      new TableRow({
-        children: row.map((cell) => tableCell(cell)),
-      }),
-    )
+  for (const row of bodyRows) {
+    rows.push(new TableRow({ children: row.map((cell) => tableCell(cell)) }))
   }
 
   const table = new Table({
     rows,
+    columnWidths,
+    layout: TableLayoutType.AUTOFIT,
+    width: { size: 100, type: WidthType.PERCENTAGE },
     style: "TableGridLight",
   })
-  // The docx library mis-serializes WidthType.PERCENTAGE as e.g. "5000%" and always
-  // emits tblBorders even when a named style owns them. Patch the TableProperties root
-  // directly to replace the broken width element and strip the redundant borders.
-  const tblPr = (table as unknown as { root: { root: unknown[] }[] }).root[0]
-  tblPr.root = tblPr.root.filter((el) => {
-    const name = (el as { rootKey?: string }).rootKey
-    return name !== "w:tblW" && name !== "w:tblBorders"
-  })
-  const tblW = (
-    ImportedXmlComponent.fromXmlString('<w:tblW w:w="5000" w:type="pct"/>') as unknown as {
-      root: unknown[]
-    }
-  ).root[0]
-  tblPr.root.push(tblW)
+
+  // The docx library always emits tblBorders even when a named style owns them.
+  // Strip the redundant element so TableGridLight's borders are used.
+  const tblPr = (table as unknown as { root: [{ root: unknown[] }, ...unknown[]] }).root[0]
+  tblPr.root = tblPr.root.filter((el) => (el as { rootKey?: string }).rootKey !== "w:tblBorders")
   return table
 }


### PR DESCRIPTION
Tables emitted a degenerate <w:tblGrid> with identical 100-twip placeholder columns and no reconciling layout. Word desktop silently repaired this, but Word Online / SharePoint validates the grid against the declared table width on load and save, could not reconcile it, and failed to render the table or refused to save.

Emit a full-width autofit table with content-weighted proportional gridCol hints instead. The table stays width=100%/autofit so it inherits whatever page size and margins the document uses and lets Word distribute the columns; the grid is now non-degenerate and internally consistent, which is what Word Online requires.

Also drops the manual w:tblW XML patch: it worked around an older docx version that serialized percentage widths as a broken "5000%"; docx 9.6.1 emits a valid "100%", so it is no longer needed.