### PR TITLE
fix: remove remote-code install step from convert-markdown-to-docx skill

### DIFF
--- a/skills/convert-markdown-to-docx/SKILL.md
+++ b/skills/convert-markdown-to-docx/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: convert-markdown-to-docx
-description: Converts Markdown files to Word (.docx) documents using the md-to-docx CLI. Use when the user wants to convert, export, or transform a Markdown file into a Word document or .docx format.
+description: Convert, export, or transform a Markdown file into a Word (.docx) document with the markdown-to-docx CLI.
 ---
 
 # Convert Markdown to DOCX
-
-## Install
-
-```sh
-curl -fsSL https://github.com/josefaidt/markdown-to-docx/releases/latest/download/install.sh | sh
-```
 
 ## Quick start
 
@@ -17,34 +11,9 @@ curl -fsSL https://github.com/josefaidt/markdown-to-docx/releases/latest/downloa
 markdown-to-docx <input.md> [output.docx]
 ```
 
-Output defaults to the same name and directory as the input with a `.docx` extension.
+Output defaults to the same name and directory as the input with a `.docx` extension. Pass a second argument to choose the output path.
 
-## Options
-
-| Flag                | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--template <path>` | Load styles from a `.dotx` template file                       |
-| `--header <text>`   | Left-aligned header text (skipped on first page)               |
-| `--footer <text>`   | Bottom-left footer text (page number always on the right)      |
-| `--font-size <n>`   | Base font size in pt; all styles scale from this (default: 12) |
-| `--line-numbers`    | Add line numbers to code blocks                                |
-
-## Examples
-
-**Basic conversion:**
-
-```bash
-markdown-to-docx docs/report.md
-# → docs/report.docx
-```
-
-**With custom output path:**
-
-```bash
-markdown-to-docx docs/report.md output/report.docx
-```
-
-**With header, footer, and template:**
+For the full, current flag list run `markdown-to-docx --help`. Flags combine:
 
 ```bash
 markdown-to-docx report.md \
@@ -70,18 +39,13 @@ title: My Document
 
 ## Normalizing links and images before conversion
 
-`markdown-to-docx` cannot resolve relative paths at conversion time. Before converting, rewrite any relative links and image paths to absolute URLs or absolute file paths.
+`markdown-to-docx` cannot resolve relative paths at conversion time — every relative link and image must be rewritten to an absolute URL or absolute file path first, or it breaks in the output.
 
-### Links
+Rewrite the source into a temp file, then convert that:
 
-1. Scan the markdown body for relative links — e.g. `](./other-doc.md)`, `](../assets/fig.png)`
-2. Resolve each to an absolute URL or absolute file path
-3. If a target cannot be resolved, degrade gracefully: remove the href and render the link text as bold (`**link text**`), and warn the user
+1. Copy the source to a fresh temp file — e.g. `/tmp/converting-<original-name>.md`. Regenerate it from the source every run; never reuse a prior temp file, and never modify the original.
+2. Rewrite every relative link and image in the temp file to an absolute URL or absolute file path — `](./other-doc.md)`, `](../assets/fig.png)`, `![alt](./img.png)`.
+3. For any target that cannot be resolved, degrade gracefully and warn the user: drop a link's href and render its text as bold (`**link text**`); remove an unresolvable image.
+4. Pass the temp file to `markdown-to-docx`.
 
-### Images
-
-Apply the same rule to image references: rewrite `![alt](./img.png)` to an absolute path or URL. If the image cannot be resolved, remove it and warn the user.
-
-### Workflow
-
-Write the rewritten content to a temp file (e.g. `/tmp/converting-<original-name>.md`) and pass that to `markdown-to-docx`. **Never modify the original file.** Always regenerate the temp file from the source before each conversion run — do not reuse a previously created temp file.
+Done when no relative path remains in the temp file.


### PR DESCRIPTION
## Why

Snyk flagged the `convert-markdown-to-docx` skill:

- **E005 (CRITICAL)** — Suspicious download URL: the Install section piped a remote `install.sh` from a personal GitHub releases URL straight to `sh`.
- **W012 (MEDIUM)** — Unverifiable external dependency: `curl -fsSL … | sh` fetches and executes remote code as a required setup step.

A skill should describe how to *use* the tool, not install it — so the Install section is dropped entirely, which clears both findings.

## What

- **Remove the `## Install` section** (the `curl … | sh` line) — resolves E005 + W012.
- **Cut the Options table and basic examples** — they were a stale cache of `--help` (missing `--bookmarks`/`--page-numbers`, wrong `--line-numbers` description). Point at `markdown-to-docx --help` instead, keeping only the combined-flags example the CLI help can't convey.
- **Collapse the duplicated Links/Images/Workflow subsections** into one shared normalization rule with a checkable completion criterion.
- **Sharpen the description** so the trigger verbs lead.

Net: 88 → 52 lines, no stale caches.